### PR TITLE
Add network scanner feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to NetScene
+
+Thank you for considering a contribution!
+
+## Development Setup
+
+1. Install Node.js dependencies with `npm install`.
+2. Run the application using `npm run tauri dev`.
+
+## Running Tests
+
+Rust unit tests can be executed with:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+The JavaScript side currently has no automated tests.
+
+## Coding Style
+
+- Document public functions with Rustdoc comments.
+- Prefer small, focussed commits.
+- Ensure `cargo test` passes before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 This template should help get you started developing with Tauri, React and Typescript in Vite.
 
+## Network Scanning
+
+This app exposes a command `scan_network` that lists devices found in the local
+ARP table. It can be triggered from the React UI using the **Scan Network**
+button.
+
+## Development
+
+To install dependencies and run the application:
+
+```bash
+npm install
+npm run tauri dev
+```
+
+### Running Tests
+
+The Rust backend contains unit tests for the ARP parsing logic. Run them with:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+### Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines when submitting patches.
+
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
 name = "netscene"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,5 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+regex = "1"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,83 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use regex::Regex;
+use serde::Serialize;
+use std::process::Command;
+
+/// Simple greeting command used by the template.
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
+}
+
+/// Representation of a network device discovered on the local network.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct Device {
+    /// IPv4 address of the device.
+    pub ip: String,
+    /// MAC address reported by the ARP table.
+    pub mac: String,
+}
+
+/// Parse the output of the `arp -a` command into a list of [`Device`].
+fn parse_arp_output(output: &str) -> Vec<Device> {
+    // Regex matches an IPv4 address and a MAC address consisting of hex
+    // digits separated by either ':' or '-'. The order can vary between
+    // platforms, so we keep it flexible.
+    let re = Regex::new(
+        r"(?i)([0-9]{1,3}(?:\.[0-9]{1,3}){3}).*?([0-9a-f]{2}([-:][0-9a-f]{2}){5})",
+    )
+    .expect("invalid regex");
+    output
+        .lines()
+        .filter_map(|line| {
+            re.captures(line).map(|caps| Device {
+                ip: caps.get(1).unwrap().as_str().to_string(),
+                mac: caps.get(2).unwrap().as_str().replace('-', ":"),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_linux_style() {
+        let sample = "? (192.168.1.1) at aa:bb:cc:dd:ee:ff [ether] on eth0\n? (192.168.1.2) at 11:22:33:44:55:66 [ether] on eth0";
+        let devices = parse_arp_output(sample);
+        assert_eq!(devices.len(), 2);
+        assert_eq!(devices[0], Device { ip: "192.168.1.1".into(), mac: "aa:bb:cc:dd:ee:ff".into() });
+        assert_eq!(devices[1].mac, "11:22:33:44:55:66");
+    }
+
+    #[test]
+    fn parse_macos_style() {
+        let sample = "? (192.168.1.3) at 77-88-99-aa-bb-cc on en0 ifscope [ethernet]";
+        let devices = parse_arp_output(sample);
+        assert_eq!(devices, vec![Device { ip: "192.168.1.3".into(), mac: "77:88:99:aa:bb:cc".into() }]);
+    }
+}
+
+/// Scan the local network using the system `arp` command.
+///
+/// The command output is parsed and returned to the caller. Errors from the
+/// command execution are converted into strings.
+#[tauri::command]
+async fn scan_network() -> Result<Vec<Device>, String> {
+    let output = Command::new("arp")
+        .arg("-a")
+        .output()
+        .map_err(|e| e.to_string())?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_arp_output(&stdout))
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![greet, scan_network])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,16 @@ import "./App.css";
 function App() {
   const [greetMsg, setGreetMsg] = useState("");
   const [name, setName] = useState("");
+  const [devices, setDevices] = useState<{ ip: string; mac: string }[]>([]);
 
   async function greet() {
     // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-    setGreetMsg(await invoke("greet", { name }));
+    setGreetMsg(await invoke<string>("greet", { name }));
+  }
+
+  async function scan() {
+    const result = await invoke<{ ip: string; mac: string }[]>("scan_network");
+    setDevices(result);
   }
 
   return (
@@ -44,6 +50,15 @@ function App() {
         <button type="submit">Greet</button>
       </form>
       <p>{greetMsg}</p>
+
+      <div className="row">
+        <button onClick={scan}>Scan Network</button>
+      </div>
+      <ul>
+        {devices.map((d) => (
+          <li key={d.ip}>{`${d.ip} - ${d.mac}`}</li>
+        ))}
+      </ul>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- support scanning local network using `arp -a`
- expose `scan_network` Tauri command
- add React UI for scanning devices
- document development and contribution guidelines

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: required system library not found)*
- `npm run build` *(fails: cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847aa4c0bd0833083dc7901e5e27285