### PR TITLE
Move scan button to top corner and simplify UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,116 +1,22 @@
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafb);
-}
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color: #0f0f0f;
-  background-color: #f6f6f6;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
-.container {
+body {
   margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
+  font-family: sans-serif;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
+#scan-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 }
 
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
+table,
+th,
+td {
+  border: 1px solid #000;
+  border-collapse: collapse;
 }
 
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
-  outline: none;
-}
-
-#greet-input {
-  margin-right: 5px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
-  }
-
-  a:hover {
-    color: #24c8db;
-  }
-
-  input,
-  button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
-  }
-  button:active {
-    background-color: #0f0f0f69;
-  }
+th,
+td {
+  padding: 0.25rem 0.5rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,10 @@ function App() {
   }
 
   return (
-    <main className="container">
+    <main>
       <h1>Welcome to Tauri + React</h1>
 
-      <div className="row">
+      <div>
         <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" className="logo vite" alt="Vite logo" />
         </a>
@@ -36,7 +36,6 @@ function App() {
       <p>Click on the Tauri, Vite, and React logos to learn more.</p>
 
       <form
-        className="row"
         onSubmit={(e) => {
           e.preventDefault();
           greet();
@@ -51,14 +50,23 @@ function App() {
       </form>
       <p>{greetMsg}</p>
 
-      <div className="row">
-        <button onClick={scan}>Scan Network</button>
-      </div>
-      <ul>
-        {devices.map((d) => (
-          <li key={d.ip}>{`${d.ip} - ${d.mac}`}</li>
-        ))}
-      </ul>
+      <button id="scan-button" onClick={scan}>Scan Network</button>
+      <table>
+        <thead>
+          <tr>
+            <th>IP Address</th>
+            <th>MAC Address</th>
+          </tr>
+        </thead>
+        <tbody>
+          {devices.map((d) => (
+            <tr key={d.ip}>
+              <td>{d.ip}</td>
+              <td>{d.mac}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- strip template styling and keep only minimal CSS
- move **Scan Network** button to the top right corner
- present discovered devices in a table instead of a list
- drop unused `row` classes in React component

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6847ac872d348330aeaf1d9c4f62bee7